### PR TITLE
Fix nistpages-pdf dockerfile

### DIFF
--- a/pdf/Dockerfile
+++ b/pdf/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:slim AS gembuilder
 RUN mkdir /usr/local/kramdown_latexnist
 ADD ./pdf/kramdown_latexnist /usr/local/kramdown_latexnist
 # Clean out existing gems from build
-RUN rm -v /usr/local/kramdown_latexnist/kramdown-latexnist-*.gem
+RUN rm -f /usr/local/kramdown_latexnist/kramdown-latexnist-*.gem
 WORKDIR /usr/local/kramdown_latexnist
 
 ## build gem

--- a/pdf/preprocess-pdf.py
+++ b/pdf/preprocess-pdf.py
@@ -137,7 +137,13 @@ def collect_section(config, section, site):
                 if 'template' in p:
                     template = latex_jinja_env.get_template(os.path.join(config['basedir'], p['template'])) 
                     body = template.render(body=body, section=section, part=p, headers=headers, config=config, site=site)
-            
+            elif 'template' in p:
+                # it's an object but only has the 'template' and no content, treat the body and header as empty
+                headers = {}
+                body = ''
+                template = latex_jinja_env.get_template(os.path.join(config['basedir'], p['template']))
+                body = template.render(body=body, section=section, part=p, headers=headers, config=config, site=site) 
+							           
             # run through a common section part template if it exists
             if 'part_template' in section:
                 template = latex_jinja_env.get_template(os.path.join(config['basedir'], section['part_template']))


### PR DESCRIPTION
I'm guessing you have local changes that haven't been pushed to the repo.  But here are the changes I needed to make to get the nistpages-pdf to build. 

The main fix modifying the dockerfile to clean the gems using `rm -f` instead of `rm -v`.  I'm guessing that was just a typo.  Without the force flag, a new build fails since there are no existing gems in that folder.

The other change was just updating the python preprocessing code to match what you presumably already have locally.